### PR TITLE
Update yOCTProcessTiledScan.m

### DIFF
--- a/Processing/yOCTProcessTiledScan.m
+++ b/Processing/yOCTProcessTiledScan.m
@@ -48,6 +48,7 @@ addRequired(p,'tiledScanInputFolder',@isstr);
 addRequired(p,'outputPath');
 
 % Z position stitching
+addParameter(p,'dispersionQuadraticTerm',79430000,@isnumeric);
 addParameter(p,'focusSigma',20,@isnumeric);
 addParameter(p,'focusPositionInImageZpix',NaN,@isnumeric);
 addParameter(p,'zSetOriginAsFocusOfZDepth0',true);
@@ -106,7 +107,7 @@ end
 json = awsReadJSON([tiledScanInputFolder 'ScanInfo.json']);
 
 %Figure out dispersion parameters
-if ~isfield(in,'dispersionParameterA') || isempty(in.dispersionParameterA)
+if isempty(in.dispersionQuadraticTerm)
     if isfield(json.octProbe,'DefaultDispersionParameterA')
         warning('octProbe has dispersionParameterA which is beeing depriciated in favor of dispersionQuadraticTerm. Please adjust probe.ini');
         in.dispersionParameterA = json.octProbe.DefaultDispersionParameterA;
@@ -114,8 +115,13 @@ if ~isfield(in,'dispersionParameterA') || isempty(in.dispersionParameterA)
     else
         in.dispersionQuadraticTerm = json.octProbe.DefaultDispersionQuadraticTerm;
         reconstructConfig = [reconstructConfig {'dispersionQuadraticTerm', in.dispersionQuadraticTerm}];
+        reconstructConfig = [reconstructConfig {'n', json.tissueRefractiveIndex}];
     end
+else
+    reconstructConfig = [reconstructConfig {'dispersionQuadraticTerm', in.dispersionQuadraticTerm}];
+    reconstructConfig = [reconstructConfig {'n', json.tissueRefractiveIndex}];
 end
+
 
 fp = cellfun(@(x)(awsModifyPathForCompetability([tiledScanInputFolder '\' x '\'])),json.octFolders,'UniformOutput',false);
 focusPositionInImageZpix = in.focusPositionInImageZpix;


### PR DESCRIPTION
There was a minor issue with the way the dispersion parameter was read. 
I changed the function (lines 109-120) in a way that as long as the user did not enter a dispersion value the dispersion will be taken from the probe file.  
In case the function did not accept any dispersion value (actual value or empty array) a build in default value will be taken.